### PR TITLE
Fix the localnet network option

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -36,12 +36,12 @@ const main = async() => {
   );
 
   const zeekFlag = Boolean(process.argv.filter(arg => arg === "--zeek")[0]);
-  const l1RpcUrl = String(process.argv
-    .filter(arg => arg.startsWith("l1-rpc-url"))
-    .map(arg => arg.split('=')[1])[0]);
-  const l2RpcUrl = String(process.argv
-    .filter(arg => arg.startsWith("l2-rpc-url"))
-    .map(arg => arg.split('=')[1])[0]);
+  const l1RpcUrl = process.argv
+    .filter((arg) => arg.startsWith("l1-rpc-url"))
+    .map((arg) => arg.split("=")[1])[0];
+  const l2RpcUrl = process.argv
+    .filter((arg) => arg.startsWith("l2-rpc-url"))
+    .map((arg) => arg.split("=")[1])[0];
 
   switch (option) {
     case 'create':


### PR DESCRIPTION
# What :computer: 
* Fix the localnet network option when overrides not supplied

# Why :hand:
* Currently, the value `undefined` is being cast as the string `undefined` and will cause network connection errors

# Evidence :camera:
Running
```bash
npm run build && npm uninstall -g zksync-cli && npm i -g && \
zksync-cli deposit --l1-rpc-url=http://127.0.0.1:8545
```
 resulted in the following (I manually added some `console.log(..)` statements in the `deposit.ts` command:
![image](https://github.com/matter-labs/zksync-cli/assets/1890113/680149f9-4e1d-40c7-91a0-3faac3ea3dbe)