### PR TITLE
docs: fix incorrect command name for confirming withdrawals

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ You can install this program globally with `npm i -g zksync-cli` or run the comm
 
 - `zksync-cli withdraw`: withdraws funds from zkSync 2.0 to L1 (Goerli testnet). It will ask to enter: network, recipient wallet, amount in ETH (eg 0.1) and the private key of the wallet you're sending the funds from.
 
-- `zksync-cli confirm-withdrawal`: confirms withdrawal of funds from zkSync 2.0 to L1 (Goerli testnet). It will ask to enter: network, withdrawal transaction address and the private key of the wallet you sent the funds from.
+- `zksync-cli confirm-withdraw`: confirms withdrawal of funds from zkSync 2.0 to L1 (Goerli testnet). It will ask to enter: network, withdrawal transaction address and the private key of the wallet you sent the funds from.
 
 - `zksync-cli <command> --help`: Provides detailed information about how to use a specific command. Replace <command> with the name of the command you want help with (e.g., create, deposit, withdraw, confirm-withdraw).
 

--- a/src/help.ts
+++ b/src/help.ts
@@ -21,7 +21,7 @@ export default async function () {
   console.log(
     `Withdraws funds from zkSync Era to L1. It will prompt for the network (localnet, testnet, mainnet), recipient wallet, amount in ETH (e.g., 0.1), and the private key of the wallet sending funds.\n`
   );
-  console.log(chalk.greenBright(`confirm-withdrawal`));
+  console.log(chalk.greenBright(`confirm-withdraw`));
   console.log(
     `Confirms the withdrawal of funds from zkSync to Layer 1. It will prompt for the network (localnet, testnet, mainnet), the transaction address of the withdrawal, and the private key of the wallet initiating the confirmation.\n`
   );


### PR DESCRIPTION
# What :computer: 
* Fix the inconsistent name for `confirm-withdraw` command

# Why :hand:
* `README.md` is incorrect and so was the `--help` response

# Evidence :camera:
Running
```bash
zksync-cli help
```
outputs

<img width="728" alt="image" src="https://github.com/matter-labs/zksync-cli/assets/1890113/03025c4f-97b1-4685-b760-fbc189c66da7">
