### PR TITLE
fix: short options, disable analytics logs

### DIFF
--- a/src/commands/create-project.ts
+++ b/src/commands/create-project.ts
@@ -25,7 +25,7 @@ const templates = [
   },
 ];
 
-const templateOption = new Option("-t, --template <name>", "Project template to use").choices(
+const templateOption = new Option("--t, --template <name>", "Project template to use").choices(
   templates.map((template) => template.value)
 );
 

--- a/src/commands/withdraw-finalize.ts
+++ b/src/commands/withdraw-finalize.ts
@@ -1,7 +1,7 @@
 import { Option } from "commander";
 import { prompt } from "inquirer";
 
-import { l1RpcUrlOption, l2RpcUrlOption, privateKeyOption, zeekOption } from "../common/options";
+import { chainOption, l1RpcUrlOption, l2RpcUrlOption, privateKeyOption, zeekOption } from "../common/options";
 import { l2Chains } from "../data/chains";
 import { program } from "../setup";
 import { track } from "../utils/analytics";
@@ -19,9 +19,6 @@ import zeek from "../utils/zeek";
 
 import type { DefaultTransactionOptions } from "../common/options";
 
-const chainOption = new Option("-c, --chain <chain>", "Chain to use").choices(
-  l2Chains.filter((e) => e.l1Chain).map((chain) => chain.network)
-);
 const transactionHashOption = new Option("--hash <transaction_hash>", "L2 withdrawal transaction hash to finalize");
 
 type WithdrawFinalizeOptions = DefaultTransactionOptions & {

--- a/src/common/options.ts
+++ b/src/common/options.ts
@@ -9,9 +9,9 @@ export const l1RpcUrlOption = new Option("--l1-rpc, --l1-rpc-url <URL>", "Overri
 export const l2RpcUrlOption = new Option("--l2-rpc, --l2-rpc-url <URL>", "Override L2 RPC URL");
 export const privateKeyOption = new Option("--pk, --private-key <URL>", "Private key of the sender");
 export const amountOptionCreate = (action: string) =>
-  new Option("--amount <amount>", `Amount of ETH to ${action} (eg. 0.1)`);
+  new Option("--a, --amount <amount>", `Amount of ETH to ${action} (eg. 0.1)`);
 export const recipientOptionCreate = (recipientLocation: string) =>
-  new Option("--recipient <address>", `Recipient address on ${recipientLocation} (0x address)`);
+  new Option("--to, --recipient <address>", `Recipient address on ${recipientLocation} (0x address)`);
 export const zeekOption = new Option(
   "--zeek",
   "zeek, the dev cat, will search for an inspirational quote and provide to you at the end of any command"

--- a/src/common/options.ts
+++ b/src/common/options.ts
@@ -2,12 +2,12 @@ import { Option } from "commander";
 
 import { l2Chains } from "../data/chains";
 
-export const chainOption = new Option("-c, --chain <chain>", "Chain to use").choices(
+export const chainOption = new Option("--c, --chain <chain>", "Chain to use").choices(
   l2Chains.filter((e) => e.l1Chain).map((chain) => chain.network)
 );
 export const l1RpcUrlOption = new Option("--l1-rpc, --l1-rpc-url <URL>", "Override L1 RPC URL");
 export const l2RpcUrlOption = new Option("--l2-rpc, --l2-rpc-url <URL>", "Override L2 RPC URL");
-export const privateKeyOption = new Option("-pk, --private-key <URL>", "Private key of the sender");
+export const privateKeyOption = new Option("--pk, --private-key <URL>", "Private key of the sender");
 export const amountOptionCreate = (action: string) =>
   new Option("--amount <amount>", `Amount of ETH to ${action} (eg. 0.1)`);
 export const recipientOptionCreate = (recipientLocation: string) =>

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -8,10 +8,13 @@ import type { apiObject } from "@rudderstack/rudder-sdk-node";
 const envPath = path.join(__dirname, "../../", ".env-public-analytics");
 dotenv.config({ path: envPath });
 
+console.log("process.env.RUDDER_STACK_KEY", process.env.RUDDER_STACK_KEY);
+
 let client: RudderAnalytics | undefined;
 try {
   client = new RudderAnalytics(process.env.RUDDER_STACK_KEY!, {
     dataPlaneUrl: process.env.RUDDER_STACK_DATAPLANE_URL!,
+    logLevel: "error",
   });
 } catch {
   // ignore

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -8,8 +8,6 @@ import type { apiObject } from "@rudderstack/rudder-sdk-node";
 const envPath = path.join(__dirname, "../../", ".env-public-analytics");
 dotenv.config({ path: envPath });
 
-console.log("process.env.RUDDER_STACK_KEY", process.env.RUDDER_STACK_KEY);
-
 let client: RudderAnalytics | undefined;
 try {
   client = new RudderAnalytics(process.env.RUDDER_STACK_KEY!, {


### PR DESCRIPTION
# What :computer: 
* Single-dash short options replaced with double dashed (eg. `-c` -> `--c`)
* Added short options for amount (`--a <amount>`) and recipient (`--to <address>`)
* Set analytics log level to "error"

# Why :hand:
* Single dash options were not working properly
* Make setting transaction details easier.
* Capture only essential error events in logs.

# Evidence :camera:
<img width="774" alt="image" src="https://github.com/matter-labs/zksync-cli/assets/47187316/d43d924f-25b6-483c-9a2a-f2e5813e62a4">