### PR TITLE
ci: Migration from ci-runner to matterlabs-ci-runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   release:
     name: Release
-    runs-on: [self-hosted, ci-runner]
+    runs-on: [matterlabs-ci-runner]
     environment: production release
     steps:
       - name: Checkout


### PR DESCRIPTION
Migration from deprecated self-hosted, ci-runners to matterlabs-ci-runners

We are moving from deprecated runners to stable.