### PR TITLE
fix: handle failing template installation

### DIFF
--- a/src/commands/create/groups/scripting.ts
+++ b/src/commands/create/groups/scripting.ts
@@ -25,6 +25,7 @@ export const templates: Template[] = [
     value: "node_ethers5",
     framework: "Node.js",
     ethereumFramework: "Ethers v5",
+    path: "templates/nodejs/ethers5",
     git: "https://github.com/matter-labs/zksync-scripting-templates",
   },
 ];


### PR DESCRIPTION
# What :computer: 
* Added missing scripting ethers template path
* Handle errors during project creation process

# Why :hand:
* Scripting ethers template was failing due to missing template path
* Previously, if there was an error during project creation, the spinner would be spinning indefinitely and process would not stop.

# Evidence :camera:
<img width="641" alt="image" src="https://github.com/matter-labs/zksync-cli/assets/47187316/c6ec9828-b64d-4e81-8d74-ef6cd670687e">