### PR TITLE
Update rpc URLs

### DIFF
--- a/src/commands/bridge/withdraw.ts
+++ b/src/commands/bridge/withdraw.ts
@@ -111,7 +111,6 @@ export const handler = async (options: WithdrawOptions) => {
       to: options.recipient,
       token: ETH_TOKEN.l1Address,
       amount: decimalToBigNumber(options.amount),
-      overrides: { gasLimit: 80_000_000 }, 
     });
     Logger.info("\nWithdraw sent:");
     Logger.info(` Transaction hash: ${withdrawHandle.hash}`);

--- a/src/commands/bridge/withdraw.ts
+++ b/src/commands/bridge/withdraw.ts
@@ -111,6 +111,7 @@ export const handler = async (options: WithdrawOptions) => {
       to: options.recipient,
       token: ETH_TOKEN.l1Address,
       amount: decimalToBigNumber(options.amount),
+      overrides: { gasLimit: 80_000_000 }, 
     });
     Logger.info("\nWithdraw sent:");
     Logger.info(` Transaction hash: ${withdrawHandle.hash}`);

--- a/src/data/chains.ts
+++ b/src/data/chains.ts
@@ -43,7 +43,7 @@ export const l2Chains: L2Chain[] = [
     id: 260,
     name: "Local In-memory node",
     network: "local-in-memory",
-    rpcUrl: "http://localhost:8011",
+    rpcUrl: "http://127.0.0.1:8011",
   },
   {
     id: 270,
@@ -54,7 +54,7 @@ export const l2Chains: L2Chain[] = [
       id: 9,
       name: "L1 Local",
       network: "l1-local",
-      rpcUrl: "http://localhost:8545",
+      rpcUrl: "http://127.0.0.1:8545",
     },
   },
 ];

--- a/src/data/chains.ts
+++ b/src/data/chains.ts
@@ -49,7 +49,7 @@ export const l2Chains: L2Chain[] = [
     id: 270,
     name: "Local Dockerized node",
     network: "local-dockerized",
-    rpcUrl: "http://localhost:3050",
+    rpcUrl: "http://127.0.0.1:3050",
     l1Chain: {
       id: 9,
       name: "L1 Local",


### PR DESCRIPTION
# What :computer: 

Change L2, L1 and in memory node rpc url in `chains.ts` file to use `127.0.0.1` instead of `localhost`.

# Why :hand:

Both `bridge withdraw` and `bridge deposit` operations does not work with `zksync-server` running outside docker , particullarly using the command in [zksync-era](https://github.com/matter-labs/zksync-era) because a network error occurs.

# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended