### PR TITLE
feat: update modules, command log changes, installation in correct order

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,8 +19,8 @@
         "ora": "^7.0.1",
         "update-notifier": "^7.0.0",
         "winston": "^3.10.0",
-        "zkcli-block-explorer": "^1.0.2",
-        "zkcli-dockerized-node": "^1.0.4",
+        "zkcli-block-explorer": "^1.1.0",
+        "zkcli-dockerized-node": "^1.0.5",
         "zkcli-in-memory-node": "^1.0.3",
         "zkcli-portal": "^1.0.1",
         "zksync-web3": "^0.14.4"
@@ -13176,11 +13176,13 @@
       }
     },
     "node_modules/zkcli-block-explorer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/zkcli-block-explorer/-/zkcli-block-explorer-1.0.2.tgz",
-      "integrity": "sha512-EMfHWpWDPGGz4K+ty5vLnxSiYmvCLBc1F4Kcg2sQjzQIWMqjSXS+Ur6Xuvt+VQHqrzIIlzOvhk5OCGJIBmi0oQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/zkcli-block-explorer/-/zkcli-block-explorer-1.1.0.tgz",
+      "integrity": "sha512-GaOFD9eRHINDc7XOC2/faWMWU0jgDsva85WTiDbVD8LM9lZVSXMb90kecwXZXK5iIoC1Es/cCuikTMBZG9ANJQ==",
       "dependencies": {
         "chalk": "^5.3.0",
+        "ofetch": "^1.3.3",
+        "ora": "^7.0.1",
         "zksync-cli": "^0.7.0-alpha.4"
       }
     },
@@ -13237,11 +13239,12 @@
       }
     },
     "node_modules/zkcli-dockerized-node": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/zkcli-dockerized-node/-/zkcli-dockerized-node-1.0.4.tgz",
-      "integrity": "sha512-AYNg+fSt1DTfbpJ6ofdqOUyLa9msiFPljnyQtLKImz2S7xlCZAjTkQLA7o9aWinnSgIPHecrRVxKdjW+OeNHXg==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/zkcli-dockerized-node/-/zkcli-dockerized-node-1.0.5.tgz",
+      "integrity": "sha512-3f8E3vBk8ImFfXgDXOoigmzA1h6RKZ4HKbcSSB9BdXy5kUHDEvpxqLRo0visfMKlJyKP6ufci8uNh8o1F2fcXQ==",
       "dependencies": {
         "chalk": "^5.3.0",
+        "ora": "^7.0.1",
         "zksync-cli": "^0.7.0-alpha.4"
       }
     },
@@ -22752,11 +22755,13 @@
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
     },
     "zkcli-block-explorer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/zkcli-block-explorer/-/zkcli-block-explorer-1.0.2.tgz",
-      "integrity": "sha512-EMfHWpWDPGGz4K+ty5vLnxSiYmvCLBc1F4Kcg2sQjzQIWMqjSXS+Ur6Xuvt+VQHqrzIIlzOvhk5OCGJIBmi0oQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/zkcli-block-explorer/-/zkcli-block-explorer-1.1.0.tgz",
+      "integrity": "sha512-GaOFD9eRHINDc7XOC2/faWMWU0jgDsva85WTiDbVD8LM9lZVSXMb90kecwXZXK5iIoC1Es/cCuikTMBZG9ANJQ==",
       "requires": {
         "chalk": "^5.3.0",
+        "ofetch": "^1.3.3",
+        "ora": "^7.0.1",
         "zksync-cli": "^0.7.0-alpha.4"
       },
       "dependencies": {
@@ -22802,11 +22807,12 @@
       }
     },
     "zkcli-dockerized-node": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/zkcli-dockerized-node/-/zkcli-dockerized-node-1.0.4.tgz",
-      "integrity": "sha512-AYNg+fSt1DTfbpJ6ofdqOUyLa9msiFPljnyQtLKImz2S7xlCZAjTkQLA7o9aWinnSgIPHecrRVxKdjW+OeNHXg==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/zkcli-dockerized-node/-/zkcli-dockerized-node-1.0.5.tgz",
+      "integrity": "sha512-3f8E3vBk8ImFfXgDXOoigmzA1h6RKZ4HKbcSSB9BdXy5kUHDEvpxqLRo0visfMKlJyKP6ufci8uNh8o1F2fcXQ==",
       "requires": {
         "chalk": "^5.3.0",
+        "ora": "^7.0.1",
         "zksync-cli": "^0.7.0-alpha.4"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "./lib": "./bin/lib/index.js"
   },
   "scripts": {
-    "build": "cross-env NODE_ENV=development tsc -p tsconfig.build.json",
-    "dev": "ts-node-esm src/index.ts",
+    "build": "tsc -p tsconfig.build.json",
+    "dev": "cross-env NODE_ENV=development ts-node-esm src/index.ts",
     "typecheck": "tsc -p . --noEmit",
     "lint": "eslint . --ext ./src/* --fix --ignore-path .gitignore --no-error-on-unmatched-pattern --max-warnings=0",
     "commitlint": "commitlint --edit"
@@ -44,8 +44,8 @@
     "ora": "^7.0.1",
     "update-notifier": "^7.0.0",
     "winston": "^3.10.0",
-    "zkcli-block-explorer": "^1.0.2",
-    "zkcli-dockerized-node": "^1.0.4",
+    "zkcli-block-explorer": "^1.1.0",
+    "zkcli-dockerized-node": "^1.0.5",
     "zkcli-in-memory-node": "^1.0.3",
     "zkcli-portal": "^1.0.1",
     "zksync-web3": "^0.14.4"

--- a/src/commands/dev/config.ts
+++ b/src/commands/dev/config.ts
@@ -6,11 +6,23 @@ import configHandler from "./ConfigHandler.js";
 import { ModuleCategory } from "./modules/Module.js";
 import Logger from "../../utils/logger.js";
 
+import type Module from "./modules/Module.js";
 import type { ModuleNode } from "./modules/Module.js";
 
 type LocalConfigOptions = {
   node?: string;
   modules?: string[];
+};
+
+const formatModuleName = (module: Module) => {
+  let name = `${module.name} - ${module.description}`;
+  if (process.env.NODE_ENV === "development") {
+    name += chalk.gray(` - ${module.package.name}`);
+  }
+  if (module.package.symlinked) {
+    name += chalk.gray(" (installed via --link)");
+  }
+  return name;
 };
 
 export const setupConfig = async (options: LocalConfigOptions = {}) => {
@@ -31,7 +43,7 @@ export const setupConfig = async (options: LocalConfigOptions = {}) => {
         type: "list",
         when: () => nodes.length > 0,
         choices: nodes.map((node) => ({
-          name: `${node.name} - ${node.description}`,
+          name: formatModuleName(node),
           short: node.name,
           value: node.package.name,
         })),
@@ -54,12 +66,12 @@ export const setupConfig = async (options: LocalConfigOptions = {}) => {
     potentialModules.map(async (module) => {
       try {
         return {
-          ...module,
+          instance: module,
           unsupported: (await module.isNodeSupported(nodeInfo)) ? false : "Module doesn't support selected node",
         };
       } catch (error) {
         return {
-          ...module,
+          instance: module,
           unsupported: "Failed to check node support status",
         };
       }
@@ -71,11 +83,11 @@ export const setupConfig = async (options: LocalConfigOptions = {}) => {
       return a.unsupported ? 1 : -1;
     }
     // If categories are equal, compare by name.
-    if (a.category === b.category) {
-      return a.name.localeCompare(b.name);
+    if (a.instance.category === b.instance.category) {
+      return a.instance.name.localeCompare(b.instance.name);
     }
     // Compare by category.
-    return a.category.localeCompare(b.category);
+    return a.instance.category.localeCompare(b.instance.category);
   });
 
   const modulesAnswers: LocalConfigOptions = await inquirer.prompt(
@@ -86,9 +98,9 @@ export const setupConfig = async (options: LocalConfigOptions = {}) => {
         type: "checkbox",
         when: () => sortedModules.length > 0,
         choices: sortedModules.map((module) => ({
-          name: `${module.name} - ${module.description}`,
-          short: module.name,
-          value: module.package.name,
+          name: formatModuleName(module.instance),
+          short: module.instance.name,
+          value: module.instance.package.name,
           disabled: module.unsupported,
         })),
       },
@@ -120,7 +132,7 @@ export const handler = async (options: LocalConfigOptions = {}) => {
     await setupConfig(options);
 
     Logger.info("\nConfiguration saved successfully!", { noFormat: true });
-    Logger.info(`Start configured environment with \`${chalk.magentaBright("zksync-cli dev start")}\``);
+    Logger.info(`Start configured environment with \`${chalk.magentaBright("npx zksync-cli dev start")}\``);
   } catch (error) {
     Logger.error("There was an error while configuring the testing environment:");
     Logger.error(error);

--- a/src/commands/dev/config.ts
+++ b/src/commands/dev/config.ts
@@ -17,7 +17,7 @@ export const setupConfig = async (options: LocalConfigOptions = {}) => {
   const modules = await configHandler.getAllModules();
   if (!modules.length) {
     Logger.error("No installed modules were found");
-    Logger.error("Run `zksync-cli dev install [module-name...]` to install modules.");
+    Logger.error("Run `npx zksync-cli dev install [module-name...]` to install modules.");
     return;
   }
 

--- a/src/commands/dev/install.ts
+++ b/src/commands/dev/install.ts
@@ -19,7 +19,7 @@ export const handler = async (moduleNames: string[], options: { link: boolean })
     if (moduleNames.length) {
       Logger.info(
         `\nAdd module${moduleNames.length > 1 ? "s" : ""} to your configuration with \`${chalk.magentaBright(
-          "zksync-cli dev config"
+          "npx zksync-cli dev config"
         )}\``
       );
     }

--- a/src/commands/dev/logs.ts
+++ b/src/commands/dev/logs.ts
@@ -9,7 +9,7 @@ export const handler = async () => {
     const modules = await configHandler.getConfigModules();
     if (!modules.length) {
       Logger.warn("There are no configured modules");
-      Logger.info("You can configure them with: `zksync-cli dev config");
+      Logger.info("You can configure them with: `npx zksync-cli dev config");
       return;
     }
 

--- a/src/commands/dev/modules/index.ts
+++ b/src/commands/dev/modules/index.ts
@@ -9,7 +9,7 @@ export const handler = async () => {
     const modules = await configHandler.getAllModules();
     if (!modules.length) {
       Logger.warn("There are no modules installed");
-      Logger.info("You can install modules with: `zksync-cli dev install [module-name...]");
+      Logger.info("You can install modules with: `npx zksync-cli dev install [module-name...]");
       return;
     }
 

--- a/src/commands/dev/start.ts
+++ b/src/commands/dev/start.ts
@@ -56,13 +56,13 @@ const checkForUpdates = async (modules: Module[]) => {
     if (currentVersion) {
       str += chalk.gray(` (current: ${currentVersion})`);
     }
-    str += chalk.gray(` - zksync-cli dev update ${module.package.name}`);
+    str += chalk.gray(` - npx zksync-cli dev update ${module.package.name}`);
     Logger.info(str);
   }
   if (modulesRequiringUpdates.length > 1) {
     Logger.info(
       chalk.gray(
-        `Update all modules: zksync-cli dev update ${modulesRequiringUpdates
+        `Update all modules: npx zksync-cli dev update ${modulesRequiringUpdates
           .map(({ module }) => module.package.name)
           .join(" ")}`
       )
@@ -99,7 +99,7 @@ export const handler = async () => {
     const modules = await configHandler.getConfigModules();
     if (!modules.length) {
       Logger.warn("Config does not contain any installed modules.");
-      Logger.warn("Run `zksync-cli dev config` to select which modules to use.");
+      Logger.warn("Run `npx zksync-cli dev config` to select which modules to use.");
       return;
     }
 

--- a/src/commands/dev/start.ts
+++ b/src/commands/dev/start.ts
@@ -23,8 +23,7 @@ const installModules = async (modules: Module[]) => {
 
 const startModules = async (modules: Module[]) => {
   Logger.info(`\nStarting: ${modules.map((m) => m.name).join(", ")}...`);
-  await Promise.all(modules.filter((e) => !e.startAfterNode).map((m) => m.start()));
-  await Promise.all(modules.filter((e) => e.startAfterNode).map((m) => m.start()));
+  await Promise.all(modules.map((m) => m.start()));
 };
 
 const stopOtherNodes = async (currentModules: Module[]) => {
@@ -93,7 +92,9 @@ export const handler = async () => {
   try {
     if (!configHandler.configExists) {
       await setupConfig();
-      Logger.info("");
+      Logger.info(`You can change the config later with ${chalk.blueBright("`npx zksync-cli dev config`")}\n`, {
+        noFormat: true,
+      });
     }
 
     const modules = await configHandler.getConfigModules();
@@ -103,11 +104,12 @@ export const handler = async () => {
       return;
     }
 
-    await installModules(modules);
-    await stopOtherNodes(modules);
-    await startModules(modules);
-    await checkForUpdates(modules);
-    await showStartupInfo(modules);
+    const sortedModules = [...modules.filter((e) => !e.startAfterNode), ...modules.filter((e) => e.startAfterNode)];
+    await installModules(sortedModules);
+    await stopOtherNodes(sortedModules);
+    await startModules(sortedModules);
+    await checkForUpdates(sortedModules);
+    await showStartupInfo(sortedModules);
   } catch (error) {
     Logger.error("There was an error while starting the testing environment:");
     Logger.error(error);

--- a/src/commands/dev/update.ts
+++ b/src/commands/dev/update.ts
@@ -64,7 +64,7 @@ export const handler = async (moduleNames: string[], options: ModuleUpdateOption
       }
     }
 
-    Logger.info(`\nTo make sure changes are applied use: \`${chalk.magentaBright("zksync-cli dev start")}\``);
+    Logger.info(`\nTo make sure changes are applied use: \`${chalk.magentaBright("npx zksync-cli dev start")}\``);
   } catch (error) {
     Logger.error("There was an error while updating module:");
     Logger.error(error);


### PR DESCRIPTION
# What :computer: 
* Update block explorer module to support in-memory node
* Update dockerized node with improved contracts deployment waiting loader
* Change all command logs to include `npx`
* Install order in correct order

# Why :hand:
* Include `npx` in all command logs as it is recommended way to use `zksync-cli`
* Install firstly those modules that can be started at the same time with the node, then the rest

# Evidence :camera:
<img width="641" alt="image" src="https://github.com/matter-labs/zksync-cli/assets/47187316/0f034f0a-09f2-466b-9108-0c7f334381b4">