### PR TITLE
fix: hide private key input, use combined templates repo

### DIFF
--- a/src/commands/create/groups/contracts.ts
+++ b/src/commands/create/groups/contracts.ts
@@ -19,14 +19,16 @@ export const templates: Template[] = [
     value: "hardhat_solidity",
     framework: "Hardhat",
     language: "Solidity",
-    git: "https://github.com/matter-labs/zksync-hardhat-template",
+    path: "templates/hardhat/solidity",
+    git: "https://github.com/matter-labs/zksync-contract-templates/",
   },
   {
     name: "Hardhat + Vyper",
     value: "hardhat_vyper",
     framework: "Hardhat",
     language: "Vyper",
-    git: "https://github.com/matter-labs/zksync-hardhat-vyper-template",
+    path: "templates/hardhat/vyper",
+    git: "https://github.com/matter-labs/zksync-contract-templates/",
   },
 ];
 

--- a/src/commands/create/groups/contracts.ts
+++ b/src/commands/create/groups/contracts.ts
@@ -3,6 +3,7 @@ import inquirer from "inquirer";
 
 import Logger from "../../../utils/logger.js";
 import { packageManagers } from "../../../utils/packageManager.js";
+import { isPrivateKey } from "../../../utils/validators.js";
 import { askForTemplate, setupTemplate, askForPackageManager, successfulMessage } from "../utils.js";
 
 import type { GenericTemplate } from "../index.js";
@@ -41,7 +42,13 @@ export default async (folderLocation: string, folderRelativePath: string, templa
       name: "privateKey",
       suffix: chalk.gray(" (optional)"),
       type: "input",
-      required: true,
+      validate: (input: string) => {
+        if (!input) return true; // since it's optional
+        return isPrivateKey(input);
+      },
+      transformer: (input: string) => {
+        return input.replace(/./g, "*");
+      },
     },
   ]);
   env = {


### PR DESCRIPTION
# What :computer: 
* Hide private key input in `create` command
* Use a single repo for all contract templates

# Why :hand:
* Hide private key input for privacy/security reason
* For consistency with other templates all contracts were moved to a [single repo](https://github.com/matter-labs/zksync-contract-templates/)

# Evidence :camera:
<img width="678" alt="image" src="https://github.com/matter-labs/zksync-cli/assets/47187316/42d857f0-fca0-44f3-931f-35f07b3030d2">
