### PR TITLE
Add option to query an account's balance on a given erc20 contract

### DIFF
--- a/src/commands/wallet/balance.ts
+++ b/src/commands/wallet/balance.ts
@@ -1,7 +1,7 @@
 import inquirer from "inquirer";
 
 import Program from "./command.js";
-import { accountOption, chainOption, l2RpcUrlOption, zeekOption } from "../../common/options.js";
+import { accountOption, chainOption, l2RpcUrlOption, erc20AddressOption, zeekOption } from "../../common/options.js";
 import { l2Chains } from "../../data/chains.js";
 import { bigNumberToDecimal } from "../../utils/formatters.js";
 import { getL2Provider, optionNameToParam } from "../../utils/helpers.js";
@@ -15,6 +15,7 @@ type BalanceOptions = DefaultOptions & {
   chain?: string;
   l2RpcUrl?: string;
   address?: string;
+  erc20Address?: string;
 };
 
 export const handler = async (options: BalanceOptions) => {
@@ -52,9 +53,16 @@ export const handler = async (options: BalanceOptions) => {
 
     const selectedChain = l2Chains.find((e) => e.network === options.chain);
     const l2Provider = getL2Provider(options.l2RpcUrl ?? selectedChain!.rpcUrl);
-    const balance = await l2Provider.getBalance(options.address!);
+    if (options.erc20Address) {
+      const tokenName = "name";
+      const balance = await l2Provider.getBalance(options.address!);
+      Logger.info(`\n${selectedChain?.name} Balance: ${bigNumberToDecimal(balance)} ${tokenName}`);
 
-    Logger.info(`\n${selectedChain?.name} Balance: ${bigNumberToDecimal(balance)} ETH`);
+    } else {
+      const balance = await l2Provider.getBalance(options.address ?? "Unknown account");
+      Logger.info(`\n${selectedChain?.name} Balance: ${bigNumberToDecimal(balance)} ETH`);
+    }
+
 
     if (options.zeek) {
       zeek();
@@ -70,5 +78,6 @@ Program.command("balance")
   .addOption(chainOption)
   .addOption(l2RpcUrlOption)
   .addOption(accountOption)
+  .addOption(erc20AddressOption)
   .addOption(zeekOption)
   .action(handler);

--- a/src/commands/wallet/balance.ts
+++ b/src/commands/wallet/balance.ts
@@ -73,7 +73,7 @@ export const handler = async (options: BalanceOptions) => {
 
       const tokenName = utils.IERC20.decodeFunctionResult("name()", tokenNameResponse);
       const balance = utils.IERC20.decodeFunctionResult("balanceOf(address)", balanceResponse);
-      Logger.info(`\n${selectedChain?.name} Balance: ${bigNumberToDecimal(balance)} ${tokenName}`);
+      Logger.info(`\n${selectedChain?.name} Balance: ${balance} ${tokenName}`);
     } else {
       const balance = await l2Provider.getBalance(options.address ?? "Unknown account");
       Logger.info(`\n${selectedChain?.name} Balance: ${bigNumberToDecimal(balance)} ETH`);

--- a/src/commands/wallet/balance.ts
+++ b/src/commands/wallet/balance.ts
@@ -53,20 +53,10 @@ export const handler = async (options: BalanceOptions) => {
     };
 
     const selectedChain = l2Chains.find((e) => e.network === options.chain);
-<<<<<<< HEAD
     const l2Provider = getL2Provider(options.l2RpcUrl ?? selectedChain!.rpcUrl);
     if (options.erc20Address) {
-      const tokenName = "name";
-      const balance = await l2Provider.getBalance(options.address!);
-      Logger.info(`\n${selectedChain?.name} Balance: ${bigNumberToDecimal(balance)} ${tokenName}`);
-=======
-    const provider = getL2Provider(options.l2RpcUrl ?? selectedChain!.rpcUrl);
-
-    if (options.erc20Address) {
->>>>>>> 5e68eea... Use IERC20 encodeFunctionData. Add call
-
       const tokenNameEncodedData = utils.IERC20.encodeFunctionData("name()");
-      const balanceOfEncodedData = utils.IERC20.encodeFunctionData("balanceOf(address)", [options.account!]);
+      const balanceOfEncodedData = utils.IERC20.encodeFunctionData("balanceOf(address)", [options.address!]);
 
       const tokenNameTransactionReq = {
           to: options.erc20Address!,
@@ -78,8 +68,8 @@ export const handler = async (options: BalanceOptions) => {
         data: balanceOfEncodedData
     };
   
-      const tokenName = await provider.call(tokenNameTransactionReq);
-      const balance = await provider.call(balanceOfTransactionReq);
+      const tokenName = await l2Provider.call(tokenNameTransactionReq);
+      const balance = await l2Provider.call(balanceOfTransactionReq);
       Logger.info(`\n${selectedChain?.name} Balance: ${bigNumberToDecimal(balance)} ${tokenName}`);
     } else {
       const balance = await l2Provider.getBalance(options.address ?? "Unknown account");

--- a/src/commands/wallet/balance.ts
+++ b/src/commands/wallet/balance.ts
@@ -8,6 +8,7 @@ import { getL2Provider, optionNameToParam } from "../../utils/helpers.js";
 import Logger from "../../utils/logger.js";
 import { isAddress } from "../../utils/validators.js";
 import zeek from "../../utils/zeek.js";
+import { utils } from 'zksync-web3';
 
 import type { DefaultOptions } from "../../common/options.js";
 
@@ -52,12 +53,34 @@ export const handler = async (options: BalanceOptions) => {
     };
 
     const selectedChain = l2Chains.find((e) => e.network === options.chain);
+<<<<<<< HEAD
     const l2Provider = getL2Provider(options.l2RpcUrl ?? selectedChain!.rpcUrl);
     if (options.erc20Address) {
       const tokenName = "name";
       const balance = await l2Provider.getBalance(options.address!);
       Logger.info(`\n${selectedChain?.name} Balance: ${bigNumberToDecimal(balance)} ${tokenName}`);
+=======
+    const provider = getL2Provider(options.l2RpcUrl ?? selectedChain!.rpcUrl);
 
+    if (options.erc20Address) {
+>>>>>>> 5e68eea... Use IERC20 encodeFunctionData. Add call
+
+      const tokenNameEncodedData = utils.IERC20.encodeFunctionData("name()");
+      const balanceOfEncodedData = utils.IERC20.encodeFunctionData("balanceOf(address)", [options.account!]);
+
+      const tokenNameTransactionReq = {
+          to: options.erc20Address!,
+          data: tokenNameEncodedData
+      };
+
+      const balanceOfTransactionReq = {
+        to: options.erc20Address!,
+        data: balanceOfEncodedData
+    };
+  
+      const tokenName = await provider.call(tokenNameTransactionReq);
+      const balance = await provider.call(balanceOfTransactionReq);
+      Logger.info(`\n${selectedChain?.name} Balance: ${bigNumberToDecimal(balance)} ${tokenName}`);
     } else {
       const balance = await l2Provider.getBalance(options.address ?? "Unknown account");
       Logger.info(`\n${selectedChain?.name} Balance: ${bigNumberToDecimal(balance)} ETH`);

--- a/src/commands/wallet/balance.ts
+++ b/src/commands/wallet/balance.ts
@@ -68,8 +68,11 @@ export const handler = async (options: BalanceOptions) => {
         data: balanceOfEncodedData
     };
   
-      const tokenName = await l2Provider.call(tokenNameTransactionReq);
-      const balance = await l2Provider.call(balanceOfTransactionReq);
+      const tokenNameResponse = await l2Provider.call(tokenNameTransactionReq);
+      const balanceResponse = await l2Provider.call(balanceOfTransactionReq);
+
+      const tokenName = utils.IERC20.decodeFunctionResult("name()", tokenNameResponse);
+      const balance = utils.IERC20.decodeFunctionResult("balanceOf(address)", balanceResponse);
       Logger.info(`\n${selectedChain?.name} Balance: ${bigNumberToDecimal(balance)} ${tokenName}`);
     } else {
       const balance = await l2Provider.getBalance(options.address ?? "Unknown account");

--- a/src/common/options.ts
+++ b/src/common/options.ts
@@ -7,6 +7,7 @@ export const chainOption = new Option("--c, --chain <chain>", "Chain to use").ch
 );
 export const l1RpcUrlOption = new Option("--l1-rpc, --l1-rpc-url <URL>", "Override L1 RPC URL");
 export const l2RpcUrlOption = new Option("--l2-rpc, --l2-rpc-url <URL>", "Override L2 RPC URL");
+export const erc20AddressOption = new Option("--erc20-address, --erc20-address <ADDRESS>", "ERC20 token address to query");
 export const accountOption = new Option("--address, --address <ADDRESS>", "Account address");
 export const privateKeyOption = new Option("--pk, --private-key <URL>", "Private key of the sender");
 export const amountOptionCreate = (action: string) =>


### PR DESCRIPTION
# What :computer: 
Modify the existing `balance` command to add `--erc20-address` option

# Why :hand:
To be able to query the balance of an ERC20 token

# Evidence :camera:
![image](https://github.com/matter-labs/zksync-cli/assets/18274602/7ed82ba1-018f-4f60-b69a-cc052d6d34e1)