### PR TITLE
feat: add zksync sepolia testnet

### DIFF
--- a/src/data/chains.ts
+++ b/src/data/chains.ts
@@ -20,17 +20,24 @@ const goerli: Chain = {
   rpcUrl: "https://rpc.ankr.com/eth_goerli",
   explorerUrl: "https://goerli.etherscan.io",
 };
+const sepolia: Chain = {
+  id: 11155111,
+  name: "Ethereum Sepolia",
+  network: "sepolia",
+  rpcUrl: "https://rpc.ankr.com/eth_sepolia",
+  explorerUrl: "https://sepolia.etherscan.io",
+};
 
 export type L2Chain = Chain & { l1Chain?: Chain; verificationApiUrl?: string };
 export const l2Chains: L2Chain[] = [
   {
-    id: 280,
-    name: "zkSync Goerli Testnet",
-    network: "zksync-goerli",
-    rpcUrl: "https://testnet.era.zksync.dev",
-    explorerUrl: "https://goerli.explorer.zksync.io",
-    verificationApiUrl: "https://zksync2-testnet-explorer.zksync.dev",
-    l1Chain: goerli,
+    id: 300,
+    name: "zkSync Sepolia Testnet",
+    network: "zksync-sepolia",
+    rpcUrl: "https://sepolia.era.zksync.dev",
+    explorerUrl: "https://sepolia.explorer.zksync.io",
+    verificationApiUrl: "https://explorer.sepolia.era.zksync.dev",
+    l1Chain: sepolia,
   },
   {
     id: 324,
@@ -40,6 +47,16 @@ export const l2Chains: L2Chain[] = [
     explorerUrl: "https://explorer.zksync.io",
     verificationApiUrl: "https://zksync2-mainnet-explorer.zksync.io",
     l1Chain: mainnet,
+  },
+  {
+    // deprecated network
+    id: 280,
+    name: "zkSync Goerli Testnet",
+    network: "zksync-goerli",
+    rpcUrl: "https://testnet.era.zksync.dev",
+    explorerUrl: "https://goerli.explorer.zksync.io",
+    verificationApiUrl: "https://zksync2-testnet-explorer.zksync.dev",
+    l1Chain: goerli,
   },
   {
     id: 260,


### PR DESCRIPTION
# What :computer: 
* Add zkSync Sepolia Testnet

# Why :hand:
* Since Goerli testnet is being deprecated and Sepolia becomes the main zkSync Testnet

# Evidence :camera:
<img width="230" alt="image" src="https://github.com/matter-labs/zksync-cli/assets/47187316/8f2fcbe6-8b9c-4f69-9d08-f7813de287da">