### PR TITLE
chore(docs): update testnet docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ See full documentation and advanced examples [here](./docs/contract-interaction.
 
 ### 🔗 Supported bridge chains
 
-By default zkSync CLI bridge commands support Era Testnet and Era Mainnet. You can also use other networks by overwriting L1 and L2 RPC URLs. For example: `npx zksync-cli deposit --rpc=http://... --l1-rpc=http://...`
+By default zkSync CLI bridge commands support zkSync Sepolia and Goerli Testnet and zkSync Mainnet. You can also use other networks by overwriting L1 and L2 RPC URLs. For example: `npx zksync-cli deposit --rpc=http://... --l1-rpc=http://...`
 
 If you're using [local setup (dockerized testing node)](https://github.com/matter-labs/local-setup) with default L1 and L2 RPC URLs, you can select `Local Dockerized node` option in the CLI or provide option `--chain local-dockerized`.
 
@@ -72,7 +72,7 @@ If you're using [local setup (dockerized testing node)](https://github.com/matte
 ### Run in development mode
 
 1. Install all dependencies with `npm i`.
-2. To use CLI in development mode run `npm run dev -- [command] [options]` (e.g. `npm run dev -- bridge deposit --chain=zksync-goerli`).
+2. To use CLI in development mode run `npm run dev -- [command] [options]` (e.g. `npm run dev -- bridge deposit --chain=zksync-sepolia`).
 
 ### Building for production
 

--- a/docs/contract-interaction.md
+++ b/docs/contract-interaction.md
@@ -72,8 +72,8 @@ npx zksync-cli contract read
 ```
 You will be prompted to select a chain, contract address, and method.
 ```bash
-? Chain to use: zkSync Goerli Testnet
-? Contract address: 0x3e7676937A7E96CFB7616f255b9AD9FF47363D4b
+? Chain to use: zkSync Sepolia Testnet
+? Contract address: 0x45E6dC995113fd3d1A3b1964493105B9AA9a9A42
 ```
 
 Next you need to select a **method (function) to call**.
@@ -115,8 +115,8 @@ Finally, you will be asked the **method output** type to decode the response. Yo
 **Tip**: after running command with prompts you will see a full command with all the options that you can copy and use later to quickly run the same command again. For example:
 ```bash
 npx zksync-cli contract read \
-  --chain "zksync-goerli" \
-  --contract "0x3e7676937A7E96CFB7616f255b9AD9FF47363D4b" \
+  --chain "zksync-sepolia" \
+  --contract "0x45E6dC995113fd3d1A3b1964493105B9AA9a9A42" \
   --method "balanceOf(address)" \
   --args "0xa1cf087DB965Ab02Fb3CFaCe1f5c63935815f044" \
   --output "uint256"
@@ -134,8 +134,8 @@ npx zksync-cli contract write
 ```
 You will be prompted to select a chain, contract address, and method.
 ```bash
-? Chain to use: zkSync Goerli Testnet
-? Contract address: 0x3e7676937A7E96CFB7616f255b9AD9FF47363D4b
+? Chain to use: zkSync Sepolia Testnet
+? Contract address: 0x45E6dC995113fd3d1A3b1964493105B9AA9a9A42
 ```
 
 Next you need to select a **method (function) to call**.
@@ -174,10 +174,10 @@ When submitted a contract call will be made and you'll see the transaction hash
 **Tip**: after running command with prompts you will see a full command with all the options that you can copy and use later to quickly run the same command again. For example:
 ```bash
 npx zksync-cli contract write \
-  --chain "zksync-goerli" \
-  --contract "0x3e7676937A7E96CFB7616f255b9AD9FF47363D4b" \
+  --chain "zksync-sepolia" \
+  --contract "0x45E6dC995113fd3d1A3b1964493105B9AA9a9A42" \
   --method "transfer(address to, uint256 amount)" \
-  --args "0x3e7676937A7E96CFB7616f255b9AD9FF47363D4b" "1"
+  --args "0x45E6dC995113fd3d1A3b1964493105B9AA9a9A42" "1"
 ```
 
 <br />

--- a/src/data/chains.ts
+++ b/src/data/chains.ts
@@ -13,19 +13,19 @@ const mainnet: Chain = {
   rpcUrl: "https://cloudflare-eth.com",
   explorerUrl: "https://etherscan.io",
 };
-const goerli: Chain = {
-  id: 5,
-  name: "Ethereum Goerli",
-  network: "goerli",
-  rpcUrl: "https://rpc.ankr.com/eth_goerli",
-  explorerUrl: "https://goerli.etherscan.io",
-};
 const sepolia: Chain = {
   id: 11155111,
-  name: "Ethereum Sepolia",
+  name: "Ethereum Sepolia Testnet",
   network: "sepolia",
   rpcUrl: "https://rpc.ankr.com/eth_sepolia",
   explorerUrl: "https://sepolia.etherscan.io",
+};
+const goerli: Chain = {
+  id: 5,
+  name: "Ethereum Goerli Testnet",
+  network: "goerli",
+  rpcUrl: "https://rpc.ankr.com/eth_goerli",
+  explorerUrl: "https://goerli.etherscan.io",
 };
 
 export type L2Chain = Chain & { l1Chain?: Chain; verificationApiUrl?: string };


### PR DESCRIPTION
# What :computer: 
* Replaced Goerli mentions in docs with Sepolia

# Why :hand:
* Because zkSync Goerli Testnet is being deprecated

# Evidence :camera:
N/A