### PR TITLE
feat: add support for erc20 tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ Run `npx zksync-cli dev` to see the full list of commands.
 See full documentation and advanced examples [here](./docs/contract-interaction.md).
 
 ### Wallet commands
-- `npx zksync-cli wallet transfer`: send ETH on L2 to another account
-- `npx zksync-cli wallet balance`: displays ETH balance of the specified address
+- `npx zksync-cli wallet transfer`: send funds on L2 to another account
+- `npx zksync-cli wallet balance`: displays token balance of the specified address
 
 ### Bridge commands
 - `npx zksync-cli bridge deposit`: deposits funds from Ethereum (L1) to zkSync (L2)

--- a/src/commands/bridge/withdraw-finalize.ts
+++ b/src/commands/bridge/withdraw-finalize.ts
@@ -10,6 +10,7 @@ import {
   zeekOption,
 } from "../../common/options.js";
 import { l2Chains } from "../../data/chains.js";
+import { ETH_TOKEN } from "../../utils/constants.js";
 import { bigNumberToDecimal } from "../../utils/formatters.js";
 import {
   getAddressFromPrivateKey,
@@ -19,6 +20,7 @@ import {
   optionNameToParam,
 } from "../../utils/helpers.js";
 import Logger from "../../utils/logger.js";
+import { getBalance } from "../../utils/token.js";
 import { isPrivateKey, isTransactionHash } from "../../utils/validators.js";
 import zeek from "../../utils/zeek.js";
 import { getChains } from "../config/chains.js";
@@ -124,8 +126,13 @@ export const handler = async (options: WithdrawFinalizeOptions) => {
     const receipt = await finalizationHandle.wait();
     Logger.info(` Finalization transaction was mined in block ${receipt.blockNumber}`);
 
-    const senderBalance = await l1Provider.getBalance(senderWallet.address);
-    Logger.info(`\nSender L1 balance after transaction: ${bigNumberToDecimal(senderBalance)} ETH`);
+    const token = ETH_TOKEN;
+    const senderBalance = await getBalance(token.l1Address, senderWallet.address, l1Provider);
+    Logger.info(
+      `\nSender L1 balance after transaction: ${bigNumberToDecimal(senderBalance, token.decimals)} ${token.symbol} ${
+        token.name ? `(${token.name})` : ""
+      }`
+    );
 
     if (options.zeek) {
       zeek();

--- a/src/common/options.ts
+++ b/src/common/options.ts
@@ -10,10 +10,10 @@ export const chainWithL1Option = new Option("--chain <chain>", "Chain to use").c
 );
 export const l1RpcUrlOption = new Option("--l1-rpc <URL>", "Override L1 RPC URL");
 export const l2RpcUrlOption = new Option("--rpc <URL>", "Override L2 RPC URL");
+export const tokenOption = new Option("--token <0x address>", "ERC-20 token address");
 export const accountOption = new Option("--address <0x address>", "Account address");
 export const privateKeyOption = new Option("--pk, --private-key <wallet private key>", "Private key of the sender");
-export const amountOptionCreate = (action: string) =>
-  new Option("--amount <Ether amount>", `Amount of ETH to ${action}`);
+export const amountOptionCreate = (action: string) => new Option("--amount <0.1>", `Amount to ${action}`);
 export const recipientOptionCreate = (recipientLocation: string) =>
   new Option("--to, --recipient <0x address>", `Recipient address on ${recipientLocation}`);
 export const zeekOption = new Option(
@@ -33,4 +33,5 @@ export type DefaultTransactionOptions = DefaultOptions & {
 export type DefaultTransferOptions = DefaultTransactionOptions & {
   amount: string;
   recipient: string;
+  token: string;
 };

--- a/src/utils/token.ts
+++ b/src/utils/token.ts
@@ -1,0 +1,101 @@
+import { BigNumber } from "ethers";
+import { getAddress } from "ethers/lib/utils.js";
+import { utils } from "zksync-web3";
+
+import { ETH_TOKEN } from "./constants.js";
+
+import type { BigNumberish, ethers } from "ethers";
+import type { Provider } from "zksync-web3";
+
+type Token = {
+  address: string;
+  symbol: string;
+  name: string;
+  decimals: number;
+  l1Address?: string;
+};
+
+const getTokenAddresses = async (
+  tokenAddress: string,
+  provider: Provider,
+  l1Provider?: ethers.providers.JsonRpcProvider
+) => {
+  let tokenL2Address: string | undefined;
+  let tokenL1Address: string | undefined;
+  if ((await provider.getCode(tokenAddress)) === "0x") {
+    tokenL1Address = tokenAddress;
+    const l2Address = await provider.l2TokenAddress(tokenAddress);
+    if (!l1Provider || (await l1Provider.getCode(tokenAddress)) === "0x") {
+      throw new Error("Token with specified address was not found");
+    }
+    if ((await provider.getCode(l2Address)) !== "0x") {
+      tokenL2Address = l2Address;
+    }
+  } else {
+    tokenL2Address = tokenAddress;
+    const l1Address = await provider.l1TokenAddress(tokenAddress);
+    // when token doesn't exist on L1 it resolves to Ether address
+    if (l1Address !== ETH_TOKEN.l1Address) {
+      tokenL1Address = l1Address;
+    }
+  }
+  return {
+    address: tokenL2Address ? getAddress(tokenL2Address) : undefined,
+    l1Address: tokenL1Address ? getAddress(tokenL1Address) : undefined,
+  };
+};
+
+export const getTokenInfo = async (
+  tokenAddress: string,
+  l2Provider: Provider,
+  l1Provider?: ethers.providers.JsonRpcProvider
+): Promise<Omit<Token, "address"> & { address?: string }> => {
+  if (tokenAddress === ETH_TOKEN.address || tokenAddress === ETH_TOKEN.l1Address) {
+    return ETH_TOKEN;
+  }
+
+  const { address, l1Address } = await getTokenAddresses(tokenAddress, l2Provider, l1Provider);
+  if (!address && !l1Provider) {
+    throw new Error("Token with specified address was not found");
+  }
+  const provider = address ? l2Provider : l1Provider!;
+  const tokenContractAddress = address || l1Address!;
+  const [symbol, name, decimals] = await Promise.all([
+    provider.call({
+      to: tokenContractAddress,
+      data: utils.IERC20.encodeFunctionData("symbol()"),
+    }),
+    provider.call({
+      to: tokenContractAddress,
+      data: utils.IERC20.encodeFunctionData("name()"),
+    }),
+    provider.call({
+      to: tokenContractAddress,
+      data: utils.IERC20.encodeFunctionData("decimals()"),
+    }),
+  ]);
+  return {
+    address,
+    symbol: utils.IERC20.decodeFunctionResult("symbol()", symbol).toString(),
+    name: utils.IERC20.decodeFunctionResult("name()", name).toString(),
+    decimals: parseInt(decimals, 16),
+    l1Address,
+  };
+};
+
+export const getBalance = async (
+  tokenAddress: string,
+  address: string,
+  provider: Provider | ethers.providers.JsonRpcProvider
+): Promise<BigNumberish> => {
+  if (tokenAddress === ETH_TOKEN.address || tokenAddress === ETH_TOKEN.l1Address) {
+    return provider.getBalance(address);
+  }
+  const balanceAbi = "balanceOf(address)";
+  return BigNumber.from(
+    await provider.call({
+      to: tokenAddress,
+      data: utils.IERC20.encodeFunctionData(balanceAbi, [address]),
+    })
+  );
+};


### PR DESCRIPTION
# What :computer: 
* Added support for erc-20 tokens for all commands - `bridge deposit`, `bridge withdraw`, `wallet balance`, `wallet transfer`

# Why :hand:
* To provide a way to interact with erc-20 tokens it is now possible to provide `--token [address]` flag for all mentioned commands

# Evidence :camera:
<img width="830" alt="image" src="https://github.com/matter-labs/zksync-cli/assets/47187316/72ee2550-ef25-4afd-bb86-a827771adbb4">

# Notes :memo:
N/A