### PR TITLE
fix: use zksync-ethers instead of zksync-web3 package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "zkcli-dockerized-node": "^1.0.9",
         "zkcli-in-memory-node": "^1.0.7",
         "zkcli-portal": "^1.0.3",
-        "zksync-web3": "^0.14.4"
+        "zksync-ethers": "^5.1.0"
       },
       "bin": {
         "zksync-cli": "bin/index.js"
@@ -13836,6 +13836,17 @@
         "zksync-cli": "bin/index.js"
       }
     },
+    "node_modules/zksync-ethers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/zksync-ethers/-/zksync-ethers-5.1.0.tgz",
+      "integrity": "sha512-iks12h2/a7aS3kLm48oQWRm5HNViJP7lnGMSx4yidEB0Xob2MTgBv5G/9x40GaiCA1Yld8XIgC5YfcMmHWnh5Q==",
+      "dependencies": {
+        "ethers": "~5.7.0"
+      },
+      "peerDependencies": {
+        "ethers": "~5.7.0"
+      }
+    },
     "node_modules/zksync-web3": {
       "version": "0.14.4",
       "resolved": "https://registry.npmjs.org/zksync-web3/-/zksync-web3-0.14.4.tgz",
@@ -23470,6 +23481,14 @@
         "zkcli-in-memory-node": "^1.0.6",
         "zkcli-portal": "^1.0.2",
         "zksync-web3": "^0.14.4"
+      }
+    },
+    "zksync-ethers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/zksync-ethers/-/zksync-ethers-5.1.0.tgz",
+      "integrity": "sha512-iks12h2/a7aS3kLm48oQWRm5HNViJP7lnGMSx4yidEB0Xob2MTgBv5G/9x40GaiCA1Yld8XIgC5YfcMmHWnh5Q==",
+      "requires": {
+        "ethers": "~5.7.0"
       }
     },
     "zksync-web3": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "zkcli-dockerized-node": "^1.0.9",
     "zkcli-in-memory-node": "^1.0.7",
     "zkcli-portal": "^1.0.3",
-    "zksync-web3": "^0.14.4"
+    "zksync-ethers": "^5.1.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.7.1",

--- a/src/commands/contract/utils/helpers.ts
+++ b/src/commands/contract/utils/helpers.ts
@@ -11,7 +11,7 @@ import Logger from "../../../utils/logger.js";
 
 import type { L2Chain } from "../../../data/chains.js";
 import type { AsyncDynamicQuestionProperty, DistinctChoice } from "inquirer";
-import type { Provider } from "zksync-web3";
+import type { Provider } from "zksync-ethers";
 
 export type ABI = Record<string, unknown>[];
 export type ContractInfo = {

--- a/src/commands/contract/utils/proxy.ts
+++ b/src/commands/contract/utils/proxy.ts
@@ -3,7 +3,7 @@ import { isAddress } from "ethers/lib/utils.js";
 
 import { ETH_TOKEN } from "../../../utils/constants.js";
 
-import type { Provider } from "zksync-web3";
+import type { Provider } from "zksync-ethers";
 
 const PROXY_CONTRACT_IMPLEMENTATION_ABI = [
   {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,5 +1,5 @@
 import { getAddress } from "ethers/lib/utils.js";
-import { L2_ETH_TOKEN_ADDRESS } from "zksync-web3/build/src/utils.js";
+import { L2_ETH_TOKEN_ADDRESS } from "zksync-ethers/build/src/utils.js";
 
 export const ETH_TOKEN = {
   symbol: "ETH",

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -2,7 +2,7 @@ import chalk from "chalk";
 import { spawn } from "child_process";
 import { ethers } from "ethers";
 import { computeAddress } from "ethers/lib/utils.js";
-import { Wallet, Provider } from "zksync-web3";
+import { Wallet, Provider } from "zksync-ethers";
 
 import { Logger } from "../lib/index.js";
 

--- a/src/utils/token.ts
+++ b/src/utils/token.ts
@@ -1,11 +1,11 @@
 import { BigNumber } from "ethers";
 import { getAddress } from "ethers/lib/utils.js";
-import { utils } from "zksync-web3";
+import { utils } from "zksync-ethers";
 
 import { ETH_TOKEN } from "./constants.js";
 
 import type { BigNumberish, ethers } from "ethers";
-import type { Provider } from "zksync-web3";
+import type { Provider } from "zksync-ethers";
 
 type Token = {
   address: string;


### PR DESCRIPTION
# What :computer: 
* Uninstall zksync-web3 package
* Install and use zksync-ethers instead

# Why :hand:
* zksync-web3 package is deprecated in favor of zksync-ethers

# Evidence :camera:
N/A