### PR TITLE
fix: import zksync-ethers constants path error (zksync-ethers >= v0.5.6)

### DIFF
--- a/src/commands/transaction/info.ts
+++ b/src/commands/transaction/info.ts
@@ -4,7 +4,6 @@ import { BigNumber, ethers } from "ethers";
 import inquirer from "inquirer";
 import ora from "ora";
 import { utils } from "zksync-ethers";
-import { BOOTLOADER_FORMAL_ADDRESS } from "zksync-ethers/build/src/utils.js";
 
 import Program from "./command.js";
 import { chainOption, l2RpcUrlOption } from "../../common/options.js";
@@ -50,7 +49,7 @@ export const handler = async (options: TransactionInfoOptions) => {
     });
     const totalFee = receipt.gasUsed.mul(receipt.effectiveGasPrice);
     const refunded = transfers.reduce((acc, transfer) => {
-      if (transfer.from === BOOTLOADER_FORMAL_ADDRESS) {
+      if (transfer.from === utils.BOOTLOADER_FORMAL_ADDRESS) {
         return acc.add(transfer.amount);
       }
       return acc;
@@ -61,7 +60,7 @@ export const handler = async (options: TransactionInfoOptions) => {
       totalFee,
       paidByPaymaster:
         !transfers.length ||
-        receipt.from !== transfers.find((transfer) => transfer.from === BOOTLOADER_FORMAL_ADDRESS)?.to,
+        receipt.from !== transfers.find((transfer) => transfer.from === utils.BOOTLOADER_FORMAL_ADDRESS)?.to,
     };
   };
   const getDecodedMethodSignature = async (hexSignature: string) => {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,10 +1,10 @@
 import { getAddress } from "ethers/lib/utils.js";
-import { L2_ETH_TOKEN_ADDRESS } from "zksync-ethers/build/src/utils.js";
+import { utils } from "zksync-ethers";
 
 export const ETH_TOKEN = {
   symbol: "ETH",
   name: "Ether",
   decimals: 18,
-  address: getAddress(L2_ETH_TOKEN_ADDRESS),
+  address: getAddress(utils.L2_ETH_TOKEN_ADDRESS),
   l1Address: "0x0000000000000000000000000000000000000000",
 };


### PR DESCRIPTION
# What :computer: 
* Fix the path error for importing constants from zksync-ethers, due to updates in zksync-ethers causing zksync-cli to fail to run after installation.

# Why :hand:
* Since zksync-ethers in version 0.5.6 changed the tsconfig's rootDir from `.` to `./src`, it altered the output directory structure, leading to errors when zksync-cli imports constants from zksync-ethers; to prevent future issues caused by dependency project directory adjustments, it's necessary to change the import method:

```ts
- import { BOOTLOADER_FORMAL_ADDRESS } from "zksync-ethers/build/src/utils.js";
- BOOTLOADER_FORMAL_ADDRESS;

+ import { utils } from "zksync-ethers";
+ utils.BOOTLOADER_FORMAL_ADDRESS;
```

[zksync-ethers in version 0.5.6 changed the tsconfig's rootDir from `.` to `./src`](https://github.com/zksync-sdk/zksync-ethers/compare/v5.5.0...v5.6.0#diff-b55cdbef4907b7045f32cc5360d48d262cca5f94062e353089f189f4460039e0L4)

# Evidence :camera:

<img width="1419" alt="image" src="https://github.com/matter-labs/zksync-cli/assets/19644290/079635b7-6282-4b6e-bdd2-d1c67b4a28bb">


# Notes :memo:
