### PR TITLE
fix: wrap pathes for docker compose in quotes

### DIFF
--- a/src/utils/docker.ts
+++ b/src/utils/docker.ts
@@ -16,7 +16,7 @@ const checkDockerInstallation = async () => {
 };
 
 const getComposeCommandBase = (dockerComposePath: string, projectDir?: string) => {
-  return `docker compose -f ${dockerComposePath} --project-directory ${projectDir ?? path.dirname(dockerComposePath)}`;
+  return `docker compose -f "${dockerComposePath}" --project-directory "${projectDir ?? path.dirname(dockerComposePath)}"`;
 };
 const createComposeCommand =
   (action: string) => async (dockerComposePath: string, projectDir?: string, additionalArgs?: string[]) => {


### PR DESCRIPTION
# What :computer: 
Fix for https://github.com/matter-labs/zksync-cli/issues/133

Paths for the docker-compose command are wrapped in quotes, which avoids problems if there are spaces in the path.