### PR TITLE
chore: update paths to reflect qs hardhat paths

### DIFF
--- a/src/commands/create/groups/quickstart.ts
+++ b/src/commands/create/groups/quickstart.ts
@@ -30,7 +30,7 @@ export const templates: Template[] = [
     framework: "Hardhat",
     ethereumFramework: "Ethers v6",
     language: "Solidity",
-    path: "templates/quickstart/hardhat/factories",
+    path: "templates/quickstart/hardhat/factory",
     git: "https://github.com/matter-labs/zksync-contract-templates/",
   },
   {

--- a/src/commands/create/groups/quickstart.ts
+++ b/src/commands/create/groups/quickstart.ts
@@ -21,7 +21,7 @@ export const templates: Template[] = [
     framework: "Hardhat",
     ethereumFramework: "Ethers v6",
     language: "Solidity",
-    path: "templates/quickstart/hello-zksync",
+    path: "templates/quickstart/hardhat/hello-zksync",
     git: "https://github.com/matter-labs/zksync-contract-templates/",
   },
   {
@@ -30,7 +30,7 @@ export const templates: Template[] = [
     framework: "Hardhat",
     ethereumFramework: "Ethers v6",
     language: "Solidity",
-    path: "templates/quickstart/factories",
+    path: "templates/quickstart/hardhat/factories",
     git: "https://github.com/matter-labs/zksync-contract-templates/",
   },
   {
@@ -39,7 +39,7 @@ export const templates: Template[] = [
     framework: "Hardhat",
     ethereumFramework: "Ethers v6",
     language: "Solidity",
-    path: "templates/quickstart/testing",
+    path: "templates/quickstart/hardhat/testing",
     git: "https://github.com/matter-labs/zksync-contract-templates/",
   },
   {
@@ -48,7 +48,7 @@ export const templates: Template[] = [
     framework: "Hardhat",
     ethereumFramework: "Ethers v6",
     language: "Solidity",
-    path: "templates/quickstart/upgradability",
+    path: "templates/quickstart/hardhat/upgradability",
     git: "https://github.com/matter-labs/zksync-contract-templates/",
   },
   {
@@ -57,7 +57,7 @@ export const templates: Template[] = [
     framework: "Hardhat",
     ethereumFramework: "Ethers v6",
     language: "Solidity",
-    path: "templates/quickstart/paymaster",
+    path: "templates/quickstart/hardhat/paymaster",
     git: "https://github.com/matter-labs/zksync-contract-templates/",
   },
 ];


### PR DESCRIPTION
Related to: https://github.com/matter-labs/zksync-contract-templates/pull/12

# What :computer: 
* Updates paths to correctly point to hardhat templates for quickstart

# Why :hand:
* They are being updated

# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended

<!-- All sections below are optional. You can erase any section not applicable to your Pull Request. -->

# Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code?