### PR TITLE
feat: consider token decimals in transfer

### DIFF
--- a/src/commands/wallet/transfer.ts
+++ b/src/commands/wallet/transfer.ts
@@ -89,7 +89,7 @@ export const handler = async (options: TransferOptions) => {
     try {
       const transferHandle = await senderWallet.transfer({
         to: options.recipient,
-        amount: decimalToBigNumber(options.amount),
+        amount: decimalToBigNumber(options.amount, token.decimals),
         token: options.token ? token.address : undefined,
       });
       const transferReceipt = await transferHandle.wait();
@@ -102,7 +102,7 @@ export const handler = async (options: TransferOptions) => {
 
       const senderBalance = await getBalance(token.address, senderWallet.address, l2Provider);
       Logger.info(
-        `\nSender L2 balance after transaction: ${bigNumberToDecimal(senderBalance)} ${token.symbol} ${
+        `\nSender L2 balance after transaction: ${bigNumberToDecimal(senderBalance, token.decimals)} ${token.symbol} ${
           token.name ? chalk.gray(`(${token.name})`) : ""
         }`
       );


### PR DESCRIPTION
# What :computer: 
* When transferring an ERC20 token, considers the decimals to ensure that the correct amount is sent.

# Why :hand:
* Ensures `transfer` supports ERC20s with decimals different from the default 18
* Aligns `transfer` with the `balance`, `deposit` and `withdraw` commands

# Evidence :camera:
Transaction using native USDC (6 decimals). It correctly sends 0.1 tokens
```
npm run dev -- wallet transfer --token 0x1d17CBcF0D6D143135aE902365D2E5e2A16538D4 --chain zksync-mainnet --recipient 0xD1DF83CA61941dbDf28A212F03E106E3FF00E38e --amount 0.1

Transfer sent:
 Transaction hash: 0x615a58c7c8ca9b2e92c364181c075224fd41549f8934b8e1f4fee8a590bc4626
 Transaction link: https://explorer.zksync.io/tx/0x615a58c7c8ca9b2e92c364181c075224fd41549f8934b8e1f4fee8a590bc4626
```

<!-- All sections below are optional. You can erase any section not applicable to your Pull Request. -->

# Notes :memo:
* Fixes https://github.com/matter-labs/zksync-cli/issues/143