### PR TITLE
fix: parse array args correctly

### DIFF
--- a/src/commands/contract/encode.ts
+++ b/src/commands/contract/encode.ts
@@ -4,7 +4,7 @@ import inquirer from "inquirer";
 
 import Program from "./command.js";
 import { abiOption, argumentsOption, methodOption } from "./common/options.js";
-import { encodeData, encodeParam, getFragmentFromSignature, getInputsFromSignature } from "./utils/formatters.js";
+import { encodeData, formatArgs, getFragmentFromSignature, getInputsFromSignature } from "./utils/formatters.js";
 import { readAbiFromFile, askAbiMethod, formatMethodString } from "./utils/helpers.js";
 import { logFullCommandFromOptions, optionNameToParam } from "../../utils/helpers.js";
 import Logger from "../../utils/logger.js";
@@ -15,7 +15,7 @@ import type { DistinctQuestion } from "inquirer";
 
 type EncodeOptions = {
   method?: string;
-  arguments?: string[];
+  arguments?: Array<string | string[]>;
   abi?: string;
 };
 
@@ -82,16 +82,6 @@ const askArguments = async (method: string, options: EncodeOptions) => {
       message: name,
       name: index.toString(),
       type: "input",
-      validate: (value: string) => {
-        try {
-          encodeParam(input, value); // throws if invalid
-          return true;
-        } catch (error) {
-          return `${chalk.redBright(
-            "Failed to encode provided argument: " + (error instanceof Error ? error.message : error)
-          )}`;
-        }
-      },
     });
   });
 
@@ -113,6 +103,7 @@ export const handler = async (options: EncodeOptions, context: Command) => {
     await askMethod(abi, options);
     await askArguments(options.method!, options);
 
+    options.arguments = formatArgs(options.method!, options.arguments!);
     const data = encodeData(options.method!, options.arguments!);
     Logger.info("");
     Logger.info(chalk.greenBright("✔ Encoded data: ") + data);

--- a/src/commands/contract/read.ts
+++ b/src/commands/contract/read.ts
@@ -16,7 +16,7 @@ import {
 import {
   decodeData,
   encodeData,
-  encodeParam,
+  formatArgs,
   getFragmentFromSignature,
   getInputValues,
   getInputsFromSignature,
@@ -48,7 +48,7 @@ const decodeSkipOption = new Option("--decode-skip", "Skip decoding response");
 type CallOptions = DefaultTransactionOptions & {
   contract?: string;
   method?: string;
-  arguments?: string[];
+  arguments?: Array<string[] | string>;
   data?: string;
   outputTypes: string[];
   from?: string;
@@ -123,16 +123,6 @@ const askArguments = async (method: string, options: CallOptions) => {
       message: name,
       name: index.toString(),
       type: "input",
-      validate: (value: string) => {
-        try {
-          encodeParam(input, value); // throws if invalid
-          return true;
-        } catch (error) {
-          return `${chalk.redBright(
-            "Failed to encode provided argument: " + (error instanceof Error ? error.message : error)
-          )}`;
-        }
-      },
     });
   });
 
@@ -230,6 +220,7 @@ export const handler = async (options: CallOptions, context: Command) => {
     if (!options.data) {
       await askArguments(options.method!, options);
     }
+    options.arguments = formatArgs(options.method!, options.arguments!);
 
     const transaction: TransactionRequest = {
       to: contractInfo.address,

--- a/src/commands/contract/utils/formatters.ts
+++ b/src/commands/contract/utils/formatters.ts
@@ -58,3 +58,24 @@ export const getMethodsFromAbi = (abi: ABI, type: "read" | "write"): ethers.util
     return contractInterface.fragments as ethers.utils.FunctionFragment[];
   }
 };
+
+/**
+ * Format method args based on the method signature into a valid
+ * encodable format.
+ *
+ * @example "42,77" => [42,77]
+ */
+export const formatArgs = (method: string, args: Array<string[] | string>) => {
+  const inputs = getInputsFromSignature(method);
+
+  return args.map((arg, index) => {
+    const input = inputs[index];
+    if (input.baseType === "array") {
+      return (arg as string)
+        .replace(/\[|\]/g, "")
+        .split(",")
+        .map((element) => element.trim());
+    }
+    return arg;
+  });
+};


### PR DESCRIPTION
For contract commands read/write/encode, the args option does not format and encode array args properly and will error.

This fixes formatting incoming args if they are arrays into a format that will encode properly. Array args can be accepted as a full string with array brackets "[42,77]" or as a string input with comma separated values without the array brackets "42,77".

Fixes #164 