### PR TITLE
feat: add get latest commit hash function

### DIFF
--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -29,22 +29,39 @@ export const cloneRepo = async (repoUrl: string, destination: string, options?: 
   await executeCommand(command, options);
 };
 
-export const getLatestReleaseVersion = async (repo: string): Promise<string> => {
-  const apiUrl = `https://api.github.com/repos/${repo}/releases/latest`;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const gitApiRequest = async (url: string): Promise<any> => {
   try {
-    const response = await fetch(apiUrl);
+    const response = await fetch(url);
     if (!response.ok) {
       throw new Error(`GitHub API request failed with status: ${response.status}`);
     }
-    const releaseInfo = await response.json();
-    if (typeof releaseInfo?.tag_name !== "string") {
-      throw new Error(`Failed to parse the latest release version: ${JSON.stringify(releaseInfo)}`);
-    }
-    return releaseInfo.tag_name;
+    return await response.json();
   } catch (error) {
     if (error instanceof Error) {
-      throw new Error(`Failed to fetch the latest release version: ${error.message}`);
+      throw new Error(`Failed to make the GitHub API request: ${error.message}`);
     }
     throw error;
   }
+};
+
+export const getLatestReleaseVersion = async (repo: string): Promise<string> => {
+  const releaseInfo = await gitApiRequest(`https://api.github.com/repos/${repo}/releases/latest`);
+  if (typeof releaseInfo?.tag_name !== "string") {
+    throw new Error(`Failed to parse the latest release version: ${JSON.stringify(releaseInfo)}`);
+  }
+  return releaseInfo.tag_name;
+};
+
+export const getLatestCommitHash = async (repo: string): Promise<string> => {
+  const commitsInfo = await gitApiRequest(`https://api.github.com/repos/${repo}/commits?per_page=1`);
+  if (!commitsInfo?.length) {
+    throw new Error(
+      `Unable to get the latest commit hash. Latest commit not found. The response: ${JSON.stringify(commitsInfo)}`
+    );
+  }
+  if (typeof commitsInfo[0].sha !== "string") {
+    throw new Error(`Failed to parse the latest commit hash: ${JSON.stringify(commitsInfo)}`);
+  }
+  return commitsInfo[0].sha;
 };


### PR DESCRIPTION
# What :computer: 
Add get latest commit hash function to the git module.

# Why :hand:
If module dependencies don't have git release versions, the module still can use commit hashes as a module version. This way, CLI can detect when the module should be updated and will suggest it to the user.