### PR TITLE
fix: working deposit for custom base token tutorial

### DIFF
--- a/src/utils/token.ts
+++ b/src/utils/token.ts
@@ -6,6 +6,7 @@ import { ETH_TOKEN } from "./constants.js";
 
 import type { BigNumberish, ethers } from "ethers";
 import type { Provider } from "zksync-ethers";
+import { L2_BASE_TOKEN_ADDRESS } from "zksync-ethers/build/utils.js";
 
 type Token = {
   address: string;
@@ -58,8 +59,8 @@ export const getTokenInfo = async (
   if (!address && !l1Provider) {
     throw new Error("Token with specified address was not found");
   }
-  const provider = address ? l2Provider : l1Provider!;
-  const tokenContractAddress = address || l1Address!;
+  const provider = address && address.toLowerCase() !== L2_BASE_TOKEN_ADDRESS ? l2Provider : l1Provider!;
+  const tokenContractAddress = address && address.toLowerCase() !== L2_BASE_TOKEN_ADDRESS ? address : l1Address!;
   const [symbol, name, decimals] = await Promise.all([
     provider.call({
       to: tokenContractAddress,


### PR DESCRIPTION
fixes an issue with bridging to a zk chain with a custom base token

**Note: I'm not 100% sure how this impacts other functions, so this may not be the best solution**

You can follow step-by-step how to reproduce following the "Custom ZK Chain" tutorial fixed here: https://github.com/zkSync-Community-Hub/community-code/pull/117

The following command currently fails:

```bash
npx zksync-cli bridge deposit \
--token <0x_YOUR_TOKEN_ADDRESS> \
--rpc=http://localhost:3150 \
--l1-rpc=http://localhost:8545 \
--amount 10 \
--pk <0xYOUR_GOVERNOR_PRIVATE_KEY> \
--to <0xYOUR_GOVERNOR_ADDRESS>
```

Below is the error:

```bash
ⓘ There was an error while depositing funds:
ⓘ call revert exception [ See: https://links.ethers.org/v5-errors-CALL_EXCEPTION ] (method="symbol()", data="0x", errorArgs=null, errorName=null, errorSignature=null, reason=null, code=CALL_EXCEPTION, version=abi/5.7.0)
```

This error occurs because it's trying to call the contract with the wrong provider. With the code in the PR, the deposit works.
