### PR TITLE
ci: Migrated to npmjs trusted-publishers OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,10 @@ on:
         required: true
         default: "main"
 
+permissions:
+  contents: write
+  id-token: write # Required for OIDC
+  
 env:
   HUSKY: 0
   CI: true
@@ -31,6 +35,4 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPMJS_NPM_MATTERLABS_AUTOMATION_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_NPM_MATTERLABS_AUTOMATION_TOKEN }}
         run: npx semantic-release

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "vitest": "^2.0.4"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   }
 }


### PR DESCRIPTION
# What :computer: 
Migrated to npmjs trusted-publishers OIDC.

# Why :hand:
npmjs token is deprecated. 

<!-- All sections below are optional. You can erase any section not applicable to your Pull Request. -->

ref ZKD-3244